### PR TITLE
Replace pyhull with scipy and other performance improvements

### DIFF
--- a/champ/champ_functions.py
+++ b/champ/champ_functions.py
@@ -71,35 +71,31 @@ def create_halfspaces_from_array(coef_array):
     For single Layer network, omit C_i's.
 
     :return: list of halfspaces.
-
     '''
+
     singlelayer = False
     if coef_array.shape[1] == 2:
         singlelayer = True
 
+    cconsts = coef_array[:, 0]
+    cgammas = coef_array[:, 1]
+    if not singlelayer:
+        comegas = coef_array[:, 2]
+
+    if singlelayer:
+        nvs = np.vstack((cgammas, np.ones(coef_array.shape[0])))
+        pts = np.vstack((np.zeros(coef_array.shape[0]), cconsts))
+    else:
+        nvs = np.vstack((cgammas, -comegas, np.ones(coef_array.shape[0])))
+        pts = np.vstack((np.zeros(coef_array.shape[0]), np.zeros(coef_array.shape[0]), cconsts))
+
+    nvs = nvs / np.linalg.norm(nvs, axis=0)
+    offs = np.sum(nvs * pts, axis=0)  # dot product on each column
+
     # array of shape (number of halfspaces, dimension+1)
     # Each row represents a halfspace by [normal; offset]
     # I.e. Ax + b <= 0 is represented by [A; b]
-    halfspaces = np.zeros((coef_array.shape[0], coef_array.shape[1] + 1))
-    for i in np.arange(coef_array.shape[0]):
-        cconst = coef_array[i, 0]
-        cgamma = coef_array[i, 1]
-        if not singlelayer:
-            comega = coef_array[i, 2]
-
-        if singlelayer:
-            nv = np.array([cgamma, 1.0])
-            pt = np.array([0, cconst])
-        else:
-            nv = np.array([cgamma, -1 * comega, 1.0])
-            pt = np.array([0, 0, cconst])
-
-        nv = nv / np.linalg.norm(nv)
-        off = np.dot(nv, pt)
-
-        halfspaces[i, :] = np.append(-1.0 * nv, off)
-
-    return halfspaces
+    return np.vstack((-nvs, offs)).T
 
 def sort_points(points):
     '''

--- a/champ/plot_domains.py
+++ b/champ/plot_domains.py
@@ -27,7 +27,7 @@ def plot_line_coefficients(coef_array,ax=None,colors=None):
     ax=plot_line_halfspaces(halfspaces,ax=ax,colors=colors)
     return ax
 
-def plot_line_halfspaces(halfspaces, ax=None, colors=None,labels=None):
+def plot_line_halfspaces(halfspaces, ax=None, colors=None, labels=None):
     '''
     Plot a list of halfspaces (lines) in 2D plane.  Each line is drawn from y-intercept to x-intercept.
 
@@ -40,24 +40,26 @@ def plot_line_halfspaces(halfspaces, ax=None, colors=None,labels=None):
 
     '''
 
-    if ax == None:
+    if ax is None:
         f = plt.figure()
         ax = f.add_subplot(111)
 
-    if colors==None:
-        cnorm=mcolors.Normalize(vmin=0,vmax=len(halfspaces))
-        cmap=cm.get_cmap("Set1")
-        pal=lmap(lambda i: cmap(cnorm(i)),range(len(halfspaces)))
+    if colors is None:
+        cnorm = mcolors.Normalize(vmin=0, vmax=len(halfspaces))
+        cmap = cm.get_cmap("Set1")
+        pal = lmap(lambda i: cmap(cnorm(i)), range(len(halfspaces)))
 
-    for i,hs in enumerate(halfspaces):
+    normals, offsets = np.split(halfspaces, [-1], axis=1)
+
+    for i, (normal, offset) in enumerate(zip(normals, offsets)):
         if hasattr(colors, "__iter__"):
-            c = colors[i%len(colors)]  # must match length
+            c = colors[i % len(colors)]  # must match length
         else:
-            c = pal[i] if colors == None else colors
+            c = pal[i] if colors is None else colors
 
-        A=-1.0*hs.offset/hs.normal[0]
-        B=-1.0*hs.offset/hs.normal[1]
-        ax.plot( [0,A],[B,0],color=c )
+        A = -1.0 * offset / normal[0]
+        B = -1.0 * offset / normal[1]
+        ax.plot([0, A], [B, 0], color=c)
 
     if labels is not None:
         if labels is True:
@@ -66,7 +68,6 @@ def plot_line_halfspaces(halfspaces, ax=None, colors=None,labels=None):
         else:
             ax.set_xlabel(labels[0])
             ax.set_ylabel(labels[1])
-
 
     return ax
 

--- a/champ/test_champ.py
+++ b/champ/test_champ.py
@@ -18,40 +18,39 @@ def main():
     logging.basicConfig(format=LOG_FORMAT,
                         level=LOG_LEVEL)
     logging.info("Command: %s", " ".join(sys.argv))
-    #create random planes
-    test_hs=[]
 
     logging.info("Multilayer Test")
-    test_hs_arry=champ.get_random_halfspaces(50)
-    logging.info("Coefficent array: "+str(test_hs_arry.shape))
+    # create random planes
+    test_hs_array = champ.get_random_halfspaces(50)
+    logging.info("Coefficent array: " + str(test_hs_array.shape))
 
-    test_hs=champ.create_halfspaces_from_array(test_hs_arry)
-    test_hs_array= np.array([[ 0.01952282, -0.31423295,  0.7157867 ],
-       [-0.25143036,  0.01881523,  0.50600329],
-       [ 0.35820641, -0.39882791,  0.50962841],
-       [ 0.29615668, -0.01859933,  0.39495284],
-       [ 0.28248495, -0.3065654 ,  0.53979975],
-       [ 0.19956666, -0.04699647,  0.41592189],
-       [-0.22016126,  0.00506596,  0.74269582],
-       [ 0.03799577, -0.04149145,  0.38461615],
-       [-0.28777492,  0.21594638,  0.65241822],
-       [ 0.01847376,  0.28849111,  0.17194509]])
+    test_hs = champ.create_halfspaces_from_array(test_hs_array)
+    # test_hs_array= np.array([[ 0.01952282, -0.31423295,  0.7157867 ],
+    #    [-0.25143036,  0.01881523,  0.50600329],
+    #    [ 0.35820641, -0.39882791,  0.50962841],
+    #    [ 0.29615668, -0.01859933,  0.39495284],
+    #    [ 0.28248495, -0.3065654 ,  0.53979975],
+    #    [ 0.19956666, -0.04699647,  0.41592189],
+    #    [-0.22016126,  0.00506596,  0.74269582],
+    #    [ 0.03799577, -0.04149145,  0.38461615],
+    #    [-0.28777492,  0.21594638,  0.65241822],
+    #    [ 0.01847376,  0.28849111,  0.17194509]])
 
-    logging.info("Number of Initial Partitions: %d" %(len(test_hs)) )
-    ind_2_doms=champ.get_intersection(test_hs_array)
-    logging.info("Number of Admissible Partitions: %d" %(len(ind_2_doms.keys())))
-    #plot domain by domain
+    logging.info("Number of Initial Partitions: %d" % (len(test_hs)))
+    ind_2_doms = champ.get_intersection(test_hs_array)
+    logging.info("Number of Admissible Partitions: %d" % (len(ind_2_doms.keys())))
+    # plot domain by domain
     # for i,dom in ind_2_doms.items():
     #     plt.close()
     #     champ.plot_2d_domains(dict([(i,dom)]))
     #     plt.show()
     plt.close()
-    ax=champ.plot_2d_domains(ind_2_doms)
+    ax = champ.plot_2d_domains(ind_2_doms)
     # print ind_2_doms
     plt.show()
 
     logging.info("Single-layer Test")
-    test_hs_arry = champ.get_random_halfspaces(100,dim=2)
+    test_hs_arry = champ.get_random_halfspaces(100, dim=2)
 
     # plt.close()
     # for i in range(test_hs_arry.shape[0]):
@@ -60,15 +59,15 @@ def main():
     # plt.show()
     test_hs = champ.create_halfspaces_from_array(test_hs_arry)
     logging.info("Number of Initial Partitions: %d" % (len(test_hs)))
-    ind_2_doms = champ.get_intersection(test_hs_arry, max_pt=(10, 10))
+    ind_2_doms = champ.get_intersection(test_hs_arry, max_pt=10)
     logging.info("Number of Admissible Partitions: %d" % (len(ind_2_doms.keys())))
 
     plt.close()
-    f,(a1,a2)=plt.subplots(1,2,figsize=(8,4))
+    f, (a1, a2) = plt.subplots(1, 2, figsize=(8, 4))
 
-    a1=champ.plot_domains.plot_line_halfspaces(test_hs,ax=a1)
-    a1.set_title("Visualization of All Parition Lines")
-    a2=champ.plot_single_layer_modularity_domains(ind_2_doms,ax=a2)
+    a1 = champ.plot_domains.plot_line_halfspaces(test_hs, ax=a1)
+    a1.set_title("Visualization of All Partition Lines")
+    a2 = champ.plot_single_layer_modularity_domains(ind_2_doms, ax=a2)
     plt.show()
 
     return 1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ options=dict( name='champ',
                  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
                  "Topic :: Scientific/Engineering :: Information Analysis",
                  ],
-    install_requires=['ipython<5.9','pyhull','matplotlib','future','numpy>1.13','h5py',
+    install_requires=['ipython<5.9','matplotlib','future','numpy>1.13','h5py',
                       'scipy','sklearn','louvain>0.6','python-igraph']
 )
 #    install_requires=['pyhull','igraph','louvain','matplotlib','numpy',]


### PR DESCRIPTION
Use of pyhull.halfspace has been completely removed in favor of scipy.spatial.HalfspaceIntersection.

get_interior_point() now uses linear programming to return an approximation to the halfspace intersection's Chebyshev center (the point "most interior" to the polytope) by randomly sampling up to 50 of the passed halfspaces. This should resolve rare floating point issues in Qhull.

If this fails, a warning is printed and get_interior_point() falls back to the "small step" approach used earlier.

Overall, champ.get_intersection seems to run about 50-100x faster now. On my machine, a computation on one million random halfspaces takes ~0.3 and ~0.6 seconds (before, ~30 and ~40 seconds) for the 2D and 3D cases, respectively.